### PR TITLE
Target tsdl 0.8 more strictly

### DIFF
--- a/opam
+++ b/opam
@@ -1,6 +1,6 @@
 opam-version: "1"
 name: "tsdl-image"
-version: "0.1"
+version: "0.1.1"
 maintainer: "Julian Squires <julian@cipht.net>"
 authors: ["Julian Squires <julian@cipht.net>"]
 homepage: "http://github.com/tokenrove/tsdl-image"
@@ -8,7 +8,8 @@ dev-repo: "https://github.com/tokenrove/tsdl-image.git"
 bug-reports: "http://github.com/tokenrove/tsdl-image/issues"
 tags: [ "bindings" "graphics" ]
 license: "BSD3"
-depends: [ "ctypes" {>= "0.4.0"} "ctypes-foreign" "tsdl" {> "0.8.1" }
+depends: [ "ctypes" {>= "0.4.0"} "ctypes-foreign"
+           "tsdl" {> "0.8.1" & < "0.9.0"}
            "oasis" {build} ]
 depexts: [
   [["debian"] ["libsdl2-image-dev"]]


### PR DESCRIPTION
So, this broke as soon as tsdl 0.9 came out.  This is my fault for writing such a loose version requirement.

I also plan to publish a new major version compatible with 0.9, but I'd like to fix this first.
