### PR TITLE
Update to tsdl 0.9.0

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -3,3 +3,4 @@ S test
 B _build/**
 PKG tsdl
 PKG ctypes
+PKG result

--- a/_oasis
+++ b/_oasis
@@ -19,7 +19,7 @@ Executable "test"
   Install:      false
   Path:         test
   BuildTools:   ocamlbuild
-  BuildDepends: tsdl, tsdl_image
+  BuildDepends: tsdl, tsdl_image, result
   MainIs:       test.ml
 
 Test test

--- a/opam
+++ b/opam
@@ -9,7 +9,7 @@ bug-reports: "http://github.com/tokenrove/tsdl-image/issues"
 tags: [ "bindings" "graphics" ]
 license: "BSD3"
 depends: [ "ctypes" {>= "0.4.0"} "ctypes-foreign"
-           "tsdl" {> "0.8.1" & < "0.9.0"}
+           "tsdl" {>= "0.9.0"}
            "result"
            "oasis" {build} ]
 depexts: [

--- a/opam
+++ b/opam
@@ -10,6 +10,7 @@ tags: [ "bindings" "graphics" ]
 license: "BSD3"
 depends: [ "ctypes" {>= "0.4.0"} "ctypes-foreign"
            "tsdl" {> "0.8.1" & < "0.9.0"}
+           "result"
            "oasis" {build} ]
 depexts: [
   [["debian"] ["libsdl2-image-dev"]]

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,10 +1,11 @@
 
 open Tsdl
 open Tsdl_image
+open Result
 
 let (>>=) o f =
-  match o with | `Error e -> failwith (Printf.sprintf "Error %s" e)
-               | `Ok a -> f a
+  match o with | Error (`Msg e) -> failwith (Printf.sprintf "Error %s" e)
+               | Ok a -> f a
 
 let () =
   ignore (Sdl.init Sdl.Init.everything);


### PR DESCRIPTION
Fixed so that it builds with Tsdl 0.9.0, and test.ml uses the Result package.
