### PR TITLE
Revert name change, drop older OCaml versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ or by emailing Julian Squires <[julian@cipht.net](mailto:julian@cipht.net)>.
 
 Via [opam](https://opam.ocaml.org/):
 
-    opam install tsdl_image
+    opam install tsdl-image
 
 ## Documentation
 

--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
 (lang dune 1.11)
-(name tsdl_image)
+(name tsdl-image)
 (explicit_js_mode)

--- a/src/dune
+++ b/src/dune
@@ -2,5 +2,5 @@
   (name tsdl_image)
   (public_name tsdl-image)
   (modules tsdl_image)
-  (libraries ctypes tsdl result)
+  (libraries ctypes tsdl)
   (c_library_flags -lSDL2_image))

--- a/src/dune
+++ b/src/dune
@@ -1,6 +1,6 @@
 (library
   (name tsdl_image)
-  (public_name tsdl_image)
+  (public_name tsdl-image)
   (modules tsdl_image)
   (libraries ctypes tsdl result)
   (c_library_flags -lSDL2_image))

--- a/src/tsdl_image.ml
+++ b/src/tsdl_image.ml
@@ -1,7 +1,6 @@
 open Ctypes
 open Foreign
 open Tsdl
-open Result
 
 module Image = struct
 

--- a/tsdl-image.opam
+++ b/tsdl-image.opam
@@ -8,11 +8,10 @@ bug-reports: "http://github.com/tokenrove/tsdl-image/issues"
 tags: [ "bindings" "graphics" ]
 license: "BSD-3-Clause"
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.08"}
   "ctypes" {>= "0.4.0"}
   "ctypes-foreign"
   "tsdl" {>= "0.9.0"}
-  "result"
   "dune" {build & >= "1.11.0"}
 ]
 depexts: [

--- a/tsdl-image.opam
+++ b/tsdl-image.opam
@@ -8,7 +8,7 @@ bug-reports: "http://github.com/tokenrove/tsdl-image/issues"
 tags: [ "bindings" "graphics" ]
 license: "BSD-3-Clause"
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.03"}
   "ctypes" {>= "0.4.0"}
   "ctypes-foreign"
   "tsdl" {>= "0.9.0"}


### PR DESCRIPTION
The name change was not necessary: in dune you can differentiate between
the name (where '-' is not allowed) and the public name (where it is),
which is used by opam in particular.

Also, drop the result dependency and so the older OCaml
versions (now >= 4.03) (see #12)